### PR TITLE
Add support for god-children into the main diggy window.

### DIFF
--- a/manifest/content_da.js
+++ b/manifest/content_da.js
@@ -59,7 +59,13 @@ function _daf_content_da(e)
            document.body.appendChild(btn);
            onResize = function() {
                btn.style.top = (miner.offsetTop + 4) + "px";
-               miner.height = isFullwindow ? document.body.clientHeight : originalHeight;
+	       var gcDivHeight = 0;
+	       var gcDiv = document.getElementById('godChildrenDiv');
+	       if (gcDiv) {
+		   gcDivHeight = gcDiv.offsetHeight;
+		   gcDiv.style.width = isFullwindow ? document.body.clientWidth : "100%";
+	       }
+               miner.height = isFullwindow ? document.body.clientHeight - gcDivHeight : originalHeight;
                miner.width = isFullwindow ? document.body.clientWidth : "100%";
            };
            refresh = function() {

--- a/manifest/content_da.js
+++ b/manifest/content_da.js
@@ -54,7 +54,7 @@ function _daf_content_da(e)
        if(miner) { // inner IFRAME has a "miner" object
            originalHeight = miner.height;
            btn = document.createElement("button");
-           Object.assign(btn, { innerText:"\u058e", title:"Toggle Full Window" });
+           Object.assign(btn, { innerText:"\u058e", title:"Toggle Full Window", id: "DAResizeButton" });
            Object.assign(btn.style, { position:"fixed", top:(miner.offsetTop + 4) + "px", left:"4px", opacity:"0.5", backgroundColor:"#66f", color:"white", fontSize:"16pt", borderRadius:"6px", padding:"0px 2px", cursor:"pointer" });
            document.body.appendChild(btn);
            onResize = function() {
@@ -85,6 +85,7 @@ function _daf_content_da(e)
                try { window.parent.postMessage(data, "https://portal.pixelfederation.com"); } catch(e) {}
                onResize();
            };
+	   btn.externalRefresh = refresh;
            btn.addEventListener("click", function() { isFullwindow = !isFullwindow; refresh(); });
            if(isFullwindow) { setTimeout(refresh, 5000); }
        }

--- a/manifest/gameDiggy.js
+++ b/manifest/gameDiggy.js
@@ -269,6 +269,14 @@
       }
 
       /*********************************************************************
+      ** @Public - getNeighbours
+      */
+       __public.getNeighbours = function()
+       {
+	   return __public.daUser.neighbours;
+       }
+       
+      /*********************************************************************
       ** @Public - Load Game User (generator.php)
       */
       __public.gameData = function(url, form)

--- a/manifest/gameDiggy.js
+++ b/manifest/gameDiggy.js
@@ -707,6 +707,7 @@
 
             data[uid] = Object.assign(save, node[n]);
             data[uid].timeUpdated = __public.daUser.time;
+	    data[uid].neighbourIndex = n;
          }
 
          // Find any old Neighbours

--- a/manifest/gameDiggy.js
+++ b/manifest/gameDiggy.js
@@ -457,12 +457,60 @@
                gameSniff = gameData = false;
                badgeStatus();
 
-               resolve(success);
+	       __public.injectGCTable();
+	       resolve(success);
             })
             .then(syncScript);
          });
 
          return promise;
+      }
+
+      __public.injectGCTable = function(daTab) {
+	  if (!daTab) {
+	      chrome.tabs.query({}, function(tabs) {
+		  var found = false;
+		  for (var i = 0; i < tabs.length; i++) {
+		      if (isGameURL(tabs[i].url)) {
+			  console.log('Found tab', tabs[i].id, 'to inject GCTable');
+			  __public.injectGCTable(tabs[i].id);
+			  found = true;
+			  break;
+		      }
+		  }
+		  if (!found) {
+		      console.error('did not find DA tab but asked to inject GCTable');
+		  }
+	      });
+
+	      return;
+	  }
+	  if (exPrefs.debug) { console.log('injecting createGCTable into tab', daTab); }
+	  chrome.webNavigation.getAllFrames({tabId: daTab}, function(frames) {
+	      var frameId = 0;
+	      for (var i = 0; i < frames.length; i++) {
+		  if (frames[i].parentFrameId == 0 && frames[i].url.includes('/miner/')) {
+		      if (frameId == 0) {
+			  console.log('found frame', frames[i]);
+			  frameId = frames[i].frameId;
+		      } else {
+			  console.error('Duplicate miner frame ids?', frameId, frames[i].frameId);
+			  frameId = -1;
+		      }
+		  }
+	      }
+	      if (frameId <= 0) {
+		  console.error('No unique miner frame id?');
+	      } else {
+		  console.log('Injecting gcTable js & css into ', daTab, '/', frameId);
+		  chrome.tabs.executeScript(daTab, { file: 'manifest/gcTable.js',
+						     allFrames: false, frameId: frameId },
+					    function(results) { console.log('executeScript:', results); });
+		  chrome.tabs.insertCSS(daTab, { file: 'manifest/gcTable.css',
+						 allFrames: false, frameId: frameId },
+					function(results) { console.log('insertCSS:', results); });
+	      }
+	  });
       }
 
       /*

--- a/manifest/gcTable.css
+++ b/manifest/gcTable.css
@@ -1,0 +1,62 @@
+.godChildrenDiv {
+  overflow-x: scroll;
+  border: 1px solid black;
+}
+
+.godChildrenTable {
+  table-layout: fixed;
+}
+
+.friend {
+  width: 64px;
+  min-width: 50px;
+  height: 70px;
+  position: relative;
+  white-space: nowrap;
+  border: 1px solid black;
+}
+
+.level {
+  display: block;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 1;
+  left: 1;
+  float: left;
+  color: white;
+  font-size: 12px;
+}
+
+.levelbg {
+  display: block;
+  position: absolute;
+  width: 22;
+  height: 16;
+  top: 0;
+  left: 0;
+  float: left;
+  background-color: black;
+}  
+
+.name {
+  display: block;
+  position: absolute;
+  width: 48px;
+  height: 100%;
+  top: 52;
+  left: 2;
+  float: left;
+  color: black;
+  font-size: 12px;
+  text-overflow: clip;
+  overflow: hidden;
+}
+
+.friend img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 50px;
+  height: 50px;
+}

--- a/manifest/gcTable.js
+++ b/manifest/gcTable.js
@@ -46,6 +46,12 @@ function updateGCTable(result) {
 	    row.appendChild(cell);
 	}
     }
+    var resize = document.getElementById('DAResizeButton');
+    if (resize && typeof resize.externalRefresh == 'function') {
+	console.log('requesting auto-resize');
+	// Add delay so table can finish rendering before resize.
+	setTimeout(function() { resize.externalRefresh(); }, 100);
+    }
 }
 
 function getName(f) {

--- a/manifest/gcTable.js
+++ b/manifest/gcTable.js
@@ -1,0 +1,98 @@
+console.log('gcTable.js', location.href);
+
+var minerApp = document.getElementById('miner');
+if (!minerApp) {
+    console.log('unable to find miner element');
+} else {
+    console.log('found miner element');
+}
+
+chrome.runtime.sendMessage({cmd: 'getGCTable'}, updateGCTable);
+
+function updateGCTable(result) {
+    if (result.status != 'ok' || !result.result) {
+	console.error('unable to getGCTable', result);
+	return;
+    }
+    var neighbours = result.result;
+    // console.log('createGCT', neighbours);
+    var row = document.getElementById('diggyGodChildrenRow');
+    if (!row) {
+	console.log('making table...');
+	row = createGCTable();
+    }
+    var gcNeighbours = [];
+    for (var i in neighbours) {
+	if (!neighbours.hasOwnProperty(i)) continue;
+	var n = neighbours[i];
+	if (n.spawned == "0") continue;
+	if (i == 0 || i == 1) { // Mr. Bill; level 999 sorts to the right.
+	    gcNeighbours.push({name: n.name, level: 999, pic_square: n.pic_square});
+	} else {
+	    gcNeighbours.push({name: getName(n), level: parseInt(n.level), pic_square: n.pic_square});
+	}
+    }
+    gcNeighbours.sort(function(a,b) { return a.level-b.level; });
+    console.log('gcNeighbours', gcNeighbours);
+    row.innerHTML = '';
+    if (gcNeighbours.length == 0) {
+	row.innerHTML = '<td>All god children collected</td>';
+    } else {
+	for (var i = 0; i <gcNeighbours.length; i++) {
+	    var n = gcNeighbours[i];
+	    var cell = makeGodChildrenCell(n.name, n.level, n.pic_square)
+	    row.appendChild(cell);
+	}
+    }
+}
+
+function getName(f) {
+    if (f.name == '') {
+        return 'Player ' + f.uid;
+    }
+    return f.name;
+}
+
+function makeGodChildrenCell(name, level, pic) {
+    var cell = document.createElement('td');
+    cell.setAttribute('class', 'friend');
+
+    var img = document.createElement('img');
+    img.setAttribute('width', 64);
+    img.setAttribute('src', pic);
+    cell.appendChild(img);
+    cell.appendChild(makeGodChildrenSpan('levelbg', ''));
+    cell.appendChild(makeGodChildrenSpan('level', level));
+    cell.appendChild(makeGodChildrenSpan('name', name));
+
+    cell.onclick = function() { cell.parentNode.removeChild(cell); };
+    return cell;
+}
+
+function makeGodChildrenSpan(sClass, text) {
+    var span = document.createElement('span');
+    span.setAttribute('class', sClass);
+    span.innerHTML = text;
+    return span;
+}
+
+function insertAfter(afterNode, newElem) {
+    afterNode.parentNode.insertBefore(newElem, afterNode.nextSibling);
+}
+
+function createGCTable() {
+    var div = document.createElement('div');
+    div.setAttribute('class', 'godChildrenDiv');
+    div.setAttribute('id', 'godChildrenDiv');
+    insertAfter(minerApp, div);
+    var table = document.createElement('table');
+    table.setAttribute('class', 'godChildrenTable');
+    div.appendChild(table);
+    var tbody = document.createElement('tbody');
+    table.appendChild(tbody);
+    var tr = document.createElement('tr');
+    tr.setAttribute('id', 'diggyGodChildrenRow');
+    tbody.appendChild(tr);
+    return tr;
+}
+

--- a/manifest/gcTable.js
+++ b/manifest/gcTable.js
@@ -26,13 +26,15 @@ function updateGCTable(result) {
 	if (!neighbours.hasOwnProperty(i)) continue;
 	var n = neighbours[i];
 	if (n.spawned == "0") continue;
-	if (i == 0 || i == 1) { // Mr. Bill; level 999 sorts to the right.
-	    gcNeighbours.push({name: n.name, level: 999, pic_square: n.pic_square});
+	if (i == 0 || i == 1) { // Mr. Bill; index 9999 bigger than any possible 5k max friends
+	    gcNeighbours.push({name: n.name, level: '', pic_square: n.pic_square, neighbourIndex: 9999});
 	} else {
-	    gcNeighbours.push({name: getName(n), level: parseInt(n.level), pic_square: n.pic_square});
+	    gcNeighbours.push({name: getName(n), level: parseInt(n.level), pic_square: n.pic_square, neighbourIndex: n.neighbourIndex});
 	}
     }
-    gcNeighbours.sort(function(a,b) { return a.level-b.level; });
+    // Level isn't sufficient to order neighbours and I couldn't figure out
+    // what else they were using to sort (e.g. it's not uid or name)
+    gcNeighbours.sort(function(a,b) { return a.neighbourIndex - b.neighbourIndex; });
     console.log('gcNeighbours', gcNeighbours);
     row.innerHTML = '';
     if (gcNeighbours.length == 0) {
@@ -61,8 +63,10 @@ function makeGodChildrenCell(name, level, pic) {
     img.setAttribute('width', 64);
     img.setAttribute('src', pic);
     cell.appendChild(img);
-    cell.appendChild(makeGodChildrenSpan('levelbg', ''));
-    cell.appendChild(makeGodChildrenSpan('level', level));
+    if (level != '') {
+	cell.appendChild(makeGodChildrenSpan('levelbg', ''));
+	cell.appendChild(makeGodChildrenSpan('level', level));
+    }
     cell.appendChild(makeGodChildrenSpan('name', name));
 
     cell.onclick = function() { cell.parentNode.removeChild(cell); };


### PR DESCRIPTION
  * gcTable.{js,css} the injected javascript and css. Clicking on cells causes them to be removed.
  * background.js hook after XML parsing (and in debug mode reload).
  * gameDiggy.js provide a function to get at the neighbours.
  * content_da.js don't cover the GC table in fullscreen.