### PR TITLE
Work around bug in upstream gifting data. 

### DIFF
--- a/manifest/gameDiggy.js
+++ b/manifest/gameDiggy.js
@@ -1002,7 +1002,18 @@
 		return;
 	    }
 	    var back = derived.recGift[derived.recGift.length - 1];
-	    if (back.val == rec_gift) { // same value, extend the time range.
+	    if (back.val == rec_gift || // same value, extend the time range.
+		(rec_gift == 0 && daUser.derived.time <= (back.val + 2 * 86400) && daUser.derived.time >= back.val)) {
+		if (rec_gift == 0) {
+		    // This is an upstream error, they are reporting rec_gift == 0 for someone
+		    // who should still be within the 48 hour window and for which current time is after the val.
+		    if (!back.upstreamWrongZero) {
+			back.upstreamWrongZero = 1;
+		    } else {
+			back.upstreamWrongZero++;
+		    }
+		}
+
 		if (back.last <= daUser.derived.time) {
 		    back.last = daUser.derived.time;
 		} else if (!back.localClockBackwards) {

--- a/manifest/tabs/neighbours.js
+++ b/manifest/tabs/neighbours.js
@@ -394,9 +394,12 @@ var guiTabs = (function(self) {
                     return deriveError('inGiftInconsistency', 'zero_after_48hrs', n);
                 }
             }
-            if (n > 0 && recGift[n].val > 0 && recGift[n].val < recGift[n - 1].last) {
+            if (n > 0 && recGift[n].val > 0 && recGift[n-1].val > 0 && recGift[n].val < recGift[n - 1].last) {
                 // we saw the gift at n late, i.e. we saw the previous
-                // value after the current gift had already arrived.
+                // value after the current gift had already arrived, and both
+		// were valid gift dates (not the 0 of non-gifting).
+		// the second (n-1) zero check shouldn't be necessary, but there's a bug
+		// in upstream data.  See upstreamWrongZero in gameDiggy.js.
                 if ((recGift[n - 1].val + 48 * 3600) >= recGift[n].val) {
                     // This seems to only occur if the previous gift's
                     // 48 hour timeout is after the current gift's


### PR DESCRIPTION
 If the timestamp should have still been valid, ignore the 0 rec_gift that we get.  Make the check for
overlapping a little safer (both values non-zero) to work around this
bug.